### PR TITLE
Fix not RFC3339-compatible strftime output

### DIFF
--- a/LogSyslogFast.c
+++ b/LogSyslogFast.c
@@ -23,9 +23,17 @@ update_prefix(LogSyslogFast* logger, time_t t)
 
     logger->last_time = t;
 
-    /* LOG_RFC3164 time string tops out at 15 chars, LOG_RFC5424 at 24 */
-    char timestr[25];
-    strftime(timestr, 25, logger->time_format, localtime(&t));
+    /* LOG_RFC3164 time string tops out at 15 chars, LOG_RFC5424 at 25 */
+    char timestr[26];
+    strftime(timestr, 26, logger->time_format, localtime(&t));
+
+    /* %z in strftime returns 4DIGIT, but we need 2DIGIT ":" 2DIGIT */
+    if (logger->format == LOG_RFC5424) {
+        timestr[25] = 0;
+        timestr[24] = timestr[23];
+        timestr[23] = timestr[22];
+        timestr[22] = ':';
+    }
 
     logger->prefix_len = snprintf(
         logger->linebuf, logger->bufsize, logger->msg_format,

--- a/MANIFEST
+++ b/MANIFEST
@@ -6,13 +6,13 @@ ppport.h
 README
 Fast.xs
 t/00-compile.t
+t/01-Log-Syslog-Fast-PP.t
 t/01-Log-Syslog-Fast.t
 t/02-Log-Syslog-Fast-Simple.t
 t/03-corner-cases.t
 t/04-accessors.t
 t/05-ipv6.t
 t/06-large-strings.t
-t/07-Log-Syslog-Fast-PP.t
 t/08-fd-leak.t
 t/09-undef-strings.t
 t/lib/LSFServer.pm

--- a/lib/Log/Syslog/Fast/PP.pm
+++ b/lib/Log/Syslog/Fast/PP.pm
@@ -95,6 +95,7 @@ sub update_prefix {
     my $timestr = strftime("%h %e %T", localtime $t);
     if ($self->[FORMAT] == LOG_RFC5424) {
         $timestr = strftime("%Y-%m-%dT%H:%M:%S%z", localtime $t);
+        $timestr =~ s/(\d{2})$/:$1/; # see http://tools.ietf.org/html/rfc3339#section-5.6 time-numoffset
     }
 
     $self->[PREFIX] = sprintf "<%d>%s %s %s[%d]: ",

--- a/t/01-Log-Syslog-Fast.pl
+++ b/t/01-Log-Syslog-Fast.pl
@@ -331,10 +331,13 @@ sub expected_payload {
         $time_format = "%Y-%m-%dT%H:%M:%S%z";
         $msg_format = "<%d>1 %s %s %s %d - - %s";
     }
-
+    my $timestr = strftime($time_format, localtime($time));
+    if ($format == LOG_RFC5424) {
+        $timestr =~ s/(\d{2})$/:$1/;
+    }
     return sprintf $msg_format,
         ($facility << 3) | $severity,
-        strftime($time_format, localtime($time)),
+        $timestr,
         $sender, $name, $pid, $msg;
 }
 


### PR DESCRIPTION
Hello Adam,
Please have a look at this commit: it turns out that rsyslog is unable to parse messages in RFC5424 format if timestamp part is not perfectly compliant with RFC-3339.

I'm not proficient in C, so please take this with a grain of salt.