### PR TITLE
Fix ::PP constructor to make 09-undef-strings-pp.t pass on perl 5.19+

### DIFF
--- a/lib/Log/Syslog/Fast/PP.pm
+++ b/lib/Log/Syslog/Fast/PP.pm
@@ -30,9 +30,8 @@ use constant PREFIX_LEN => 7;
 use constant FORMAT     => 8;
 
 sub new {
-    $_[0] = __PACKAGE__ unless defined $_[0];
-
     my $ref = shift;
+    $ref = __PACKAGE__ unless defined $ref;
     my $class = ref $ref || $ref;
 
     my ($proto, $hostname, $port, $facility, $severity, $sender, $name) = @_;


### PR DESCRIPTION
t/09-undef-strings-pp.t fails on perl 5.19+:
http://www.cpantesters.org/cpan/report/c15fe502-b551-11e4-9bd1-14a9dfbfc7aa

This patch fixes the error introduced by fe28102c0c19bd0bd8eb3956d4ca0f4b3a4347c0 where the first argument of the constructor (the class name) is changed in place.

We now avoid to modify $_[0], and instead change the copy.