### PR TITLE
add local syslog format support

### DIFF
--- a/LogSyslogFast.c
+++ b/LogSyslogFast.c
@@ -40,8 +40,8 @@ update_prefix(LogSyslogFast* logger, time_t t)
             logger->linebuf, logger->bufsize, logger->msg_format,
             logger->priority, timestr, logger->sender, logger->name, logger->pid
         );
-    } else if (logger->format == LOG_RFC3164_LOCAL) { //without sender
-         logger->prefix_len = snprintf(
+    } else if (logger->format == LOG_RFC3164_LOCAL) { /* without sender */
+        logger->prefix_len = snprintf(
             logger->linebuf, logger->bufsize, logger->msg_format,
             logger->priority, timestr, logger->name, logger->pid
         );   
@@ -203,7 +203,7 @@ LSF_set_format(LogSyslogFast* logger, int format)
         logger->msg_format = "<%d>1 %s %s %s %d - - ";
     }
     else if (logger->format == LOG_RFC3164_LOCAL) {
-        /* Same as LOG_RFC3164 but Wthout HOSTNAME */
+        /* Same as LOG_RFC3164 but without HOSTNAME */
         logger->time_format = "%h %e %H:%M:%S";
         logger->msg_format = "<%d>%s %s[%d]: ";
     }

--- a/LogSyslogFast.c
+++ b/LogSyslogFast.c
@@ -35,10 +35,17 @@ update_prefix(LogSyslogFast* logger, time_t t)
         timestr[22] = ':';
     }
 
-    logger->prefix_len = snprintf(
-        logger->linebuf, logger->bufsize, logger->msg_format,
-        logger->priority, timestr, logger->sender, logger->name, logger->pid
-    );
+    if (logger->format == LOG_RFC3164 || logger->format == LOG_RFC5424) {
+        logger->prefix_len = snprintf(
+            logger->linebuf, logger->bufsize, logger->msg_format,
+            logger->priority, timestr, logger->sender, logger->name, logger->pid
+        );
+    } else if (logger->format == LOG_RFC3164_LOCAL) { //without sender
+         logger->prefix_len = snprintf(
+            logger->linebuf, logger->bufsize, logger->msg_format,
+            logger->priority, timestr, logger->name, logger->pid
+        );   
+    }
 
     if (logger->prefix_len > logger->bufsize - 1)
         logger->prefix_len = logger->bufsize - 1;
@@ -194,6 +201,11 @@ LSF_set_format(LogSyslogFast* logger, int format)
 
         /* STRUCTURED-DATA and MSGID fields are omitted */
         logger->msg_format = "<%d>1 %s %s %s %d - - ";
+    }
+    else if (logger->format == LOG_RFC3164_LOCAL) {
+        /* Same as LOG_RFC3164 but Wthout HOSTNAME */
+        logger->time_format = "%h %e %H:%M:%S";
+        logger->msg_format = "<%d>%s %s[%d]: ";
     }
     else {
         logger->err = "invalid format constant";

--- a/LogSyslogFast.h
+++ b/LogSyslogFast.h
@@ -5,6 +5,7 @@
 
 #define LOG_RFC3164 0
 #define LOG_RFC5424 1
+#define LOG_RFC3164_LOCAL 2
 
 typedef struct {
 
@@ -13,7 +14,7 @@ typedef struct {
     char*  sender;              /* sender hostname */
     char*  name;                /* sending program name */
     int    pid;                 /* sending program pid */
-    int    format;              /* RFC3164 or RFC5424 */
+    int    format;              /* RFC3164 or RFC5424 or RFC3164_LOCAL */
 
     /* resource handles */
     int    sock;                /* socket fd */

--- a/lib/Log/Syslog/Fast.pm
+++ b/lib/Log/Syslog/Fast.pm
@@ -157,7 +157,7 @@ Change what is sent as the process id of the sending program.
 =item $logger-E<gt>set_format($format)
 
 Change the message format. This should be either the constant LOG_RFC3164 (the
-default) or LOG_RFC5424.
+default) or LOG_RFC5424 or LOG_RFC3164_LOCAL (without HOSTNAME).
 
 =item $logger-E<gt>get_priority()
 

--- a/lib/Log/Syslog/Fast/Constants.pm
+++ b/lib/Log/Syslog/Fast/Constants.pm
@@ -17,11 +17,12 @@ use constant LOG_UNIX   => 2; # UNIX socket
 # formats
 use constant LOG_RFC3164 => 0;
 use constant LOG_RFC5424 => 1;
+use constant LOG_RFC3164_LOCAL => 2;
 
 our @EXPORT = ();
 our %EXPORT_TAGS = (
     protos =>  [qw/ LOG_TCP LOG_UDP LOG_UNIX /],
-    formats => [qw/ LOG_RFC3164 LOG_RFC5424 /],
+    formats => [qw/ LOG_RFC3164 LOG_RFC5424 LOG_RFC3164_LOCAL /],
 );
 $EXPORT_TAGS{$_} = $Log::Syslog::Constants::EXPORT_TAGS{$_}
     for qw(facilities severities);

--- a/lib/Log/Syslog/Fast/PP.pm
+++ b/lib/Log/Syslog/Fast/PP.pm
@@ -77,6 +77,10 @@ sub update_prefix {
         $self->[PREFIX] = sprintf "<%d>1 %s %s %s %d - - ",
             $self->[PRIORITY], $timestr, $self->[SENDER], $self->[NAME], $self->[PID];
     }
+    if ($self->[FORMAT] == LOG_RFC3164_LOCAL) {
+        $self->[PREFIX] = sprintf "<%d>%s %s[%d]: ",
+            $self->[PRIORITY], $timestr, $self->[NAME], $self->[PID];
+    }
 }
 
 sub set_receiver {


### PR DESCRIPTION
When using local logging (to /dev/log)  some use cases (for ex. log forwarding by syslog) implying that message format should be without hostname. It's behavior that can be seen in standard linux tool logger (https://github.com/karelzak/util-linux/blob/2bbc96228843320a825c4e0311b2dd8a77d7b533/misc-utils/logger.c#L886). This pull request add support for LOG_RFC3164_LOCAL format that skip hostname / sender.